### PR TITLE
Removing the unused import attrs

### DIFF
--- a/orm/fields.py
+++ b/orm/fields.py
@@ -2,7 +2,6 @@ import typing
 
 import sqlalchemy
 import typesystem
-from attr import attrs
 
 
 class ModelField:
@@ -46,7 +45,7 @@ class ModelField:
 
 class String(ModelField, typesystem.String):
     def __init__(self, **kwargs):
-        assert 'max_length' in kwargs, 'max_length is required'
+        assert "max_length" in kwargs, "max_length is required"
         super().__init__(**kwargs)
 
     def get_column_type(self):


### PR DESCRIPTION
Fix error 
```
  File "./app.py", line 3, in <module>
    import orm
  File "/Users/username/.local/share/virtualenvs/starlette-player-4G5BOCvo/lib/python3.7/site-packages/orm/__init__.py", line 2, in <module>
    from orm.fields import Boolean, Integer, Float, String, Text, Date, Time, DateTime, JSON, ForeignKey
  File "/Users/username/.local/share/virtualenvs/starlette-player-4G5BOCvo/lib/python3.7/site-packages/orm/fields.py", line 5, in <module>
    from attr import attrs
ModuleNotFoundError: No module named 'attr'
```
+ some linting by black