### PR TITLE
Add unique field prevalidation

### DIFF
--- a/orm/models.py
+++ b/orm/models.py
@@ -162,7 +162,7 @@ class QuerySet:
                         select_related.append(related_str)
 
                     # Walk the relationships to the actual model class
-                    #  against which the comparison is being made.
+                    # against which the comparison is being made.
                     for part in related_parts:
                         model_cls = model_cls.fields[part].to
 
@@ -336,7 +336,7 @@ class Model(typesystem.Schema, metaclass=ModelMetaclass):
 
     def __setattr__(self, key, value):
         if key in self.fields:
-            #  Setting a relationship to a raw pk value should set a
+            # Setting a relationship to a raw pk value should set a
             # fully-fledged relationship instance, with just the pk loaded.
             value = self.fields[key].expand_relationship(value)
         super().__setattr__(key, value)

--- a/orm/models.py
+++ b/orm/models.py
@@ -49,7 +49,7 @@ class ModelMetaclass(SchemaMetaclass):
 
 
 class ModelObject(typesystem.Object):
-    # NOTE: to be updated if/when typesystem handles validation of unique fieldss.
+    # NOTE: to be updated if/when typesystem handles validation of unique fields.
 
     def __init__(self, *args, queryset: "QuerySet", **kwargs):
         super().__init__(*args, **kwargs)

--- a/orm/models.py
+++ b/orm/models.py
@@ -51,14 +51,11 @@ class ModelMetaclass(SchemaMetaclass):
 class ModelObject(typesystem.Object):
     # NOTE: to be updated if/when typesystem handles validation of unique fieldss.
 
-    def __init__(self, *args, queryset: "QuerySet" = None, **kwargs):
+    def __init__(self, *args, queryset: "QuerySet", **kwargs):
         super().__init__(*args, **kwargs)
         self.queryset = queryset
 
     async def validate_unique(self, value: dict):
-        if self.queryset is None:
-            return
-
         unique_properties = {
             key: value[key] for key, val in self.properties.items() if val.unique
         }

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -100,6 +100,9 @@ async def test_model_crud():
         assert user.pk is not None
         assert users == [user]
 
+        with pytest.raises(ValueError):
+            await user.update(pk=42)
+
         await user.delete()
         users = await User.objects.all()
         assert users == []
@@ -154,5 +157,10 @@ async def test_validate_unique():
     slug = "hello-world"
     async with database:
         await Post.objects.create(slug=slug)
+
         with pytest.raises(typesystem.ValidationError):
             await Post.objects.create(slug=slug)
+
+        other = await Post.objects.create(slug="world-hello")
+        with pytest.raises(typesystem.ValidationError):
+            await other.update(slug=slug)

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -91,6 +91,9 @@ async def test_model_crud():
         assert user.pk is not None
         assert users == [user]
 
+        with pytest.raises(typesystem.ValidationError):
+            await User.objects.create(foo="is not a User field")
+
         lookup = await User.objects.get()
         assert lookup == user
 


### PR DESCRIPTION
Fixes #11 

TBH, looking at the implementation I was thinking this could be something that `typesystem` could provide a framework for.

For example, provide hook method such as `async def validate_unique_field(name, value):`, which wouldn't to anything by default, and allow `Schema` subclasses (`Model` in this case) to override it to perform any calls required to check the uniqueness constraint.