### PR TITLE
#8: Implements .limit()

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,7 @@ fantasies = await Album.objects.create(name="Fantasies")
 await Track.objects.create(album=fantasies, title="Help I'm Alive", position=1)
 await Track.objects.create(album=fantasies, title="Sick Muse", position=2)
 
+
 # Fetch an instance, without loading a foreign key relationship on it.
 track = await Track.objects.get(title="The Bird")
 
@@ -140,6 +141,10 @@ assert len(tracks) == 2
 # Fetch instances, with a filter and operator across an FK relationship.
 tracks = Track.objects.filter(album__name__iexact="fantasies")
 assert len(tracks) == 2
+
+# Limit a query
+tracks = await Track.objects.limit(1).all()
+assert len(tracks) == 1
 ```
 
 ## Data types

--- a/orm/models.py
+++ b/orm/models.py
@@ -49,9 +49,8 @@ class ModelMetaclass(SchemaMetaclass):
 
 
 class QuerySet:
+    ESCAPE_CHARACTERS = ['%', '_']
     def __init__(self, model_cls=None, filter_clauses=None, select_related=None, limit_count=None):
-        ESCAPE_CHARACTERS = ['%', '_']
-
         self.model_cls = model_cls
         self.filter_clauses = [] if filter_clauses is None else filter_clauses
         self._select_related = [] if select_related is None else select_related
@@ -178,13 +177,12 @@ class QuerySet:
         return await self.database.fetch_val(expr)
 
     def limit(self, rows_to_return: int):
-        new_query_set = self.__class__(
+        return self.__class__(
             model_cls=self.model_cls,
             filter_clauses=self.filter_clauses,
             select_related=self._select_related,
             limit_count=rows_to_return
         )
-        return new_query_set
 
     async def count(self) -> int:
         expr = self.build_select_expression()

--- a/orm/models.py
+++ b/orm/models.py
@@ -54,7 +54,7 @@ class QuerySet:
         self.model_cls = model_cls
         self.filter_clauses = [] if filter_clauses is None else filter_clauses
         self._select_related = [] if select_related is None else select_related
-        self.limit_count = None if limit_count is None else limit_count
+        self.limit_count = limit_count
 
     def __get__(self, instance, owner):
         return self.__class__(model_cls=owner)

--- a/orm/models.py
+++ b/orm/models.py
@@ -49,11 +49,11 @@ class ModelMetaclass(SchemaMetaclass):
 
 
 class QuerySet:
-    def __init__(self, model_cls=None, filter_clauses=None, select_related=None):
+    def __init__(self, model_cls=None, filter_clauses=None, select_related=None, limit_count=None):
         self.model_cls = model_cls
         self.filter_clauses = [] if filter_clauses is None else filter_clauses
         self._select_related = [] if select_related is None else select_related
-        self.limit_count = None
+        self.limit_count = None if limit_count is None else limit_count
 
     def __get__(self, instance, owner):
         return self.__class__(model_cls=owner)
@@ -147,6 +147,7 @@ class QuerySet:
             model_cls=self.model_cls,
             filter_clauses=filter_clauses,
             select_related=select_related,
+            limit_count=self.limit_count
         )
 
     def select_related(self, related):
@@ -158,6 +159,7 @@ class QuerySet:
             model_cls=self.model_cls,
             filter_clauses=self.filter_clauses,
             select_related=related,
+            limit_count=self.limit_count
         )
 
     async def exists(self) -> bool:
@@ -170,8 +172,8 @@ class QuerySet:
             model_cls=self.model_cls,
             filter_clauses=self.filter_clauses,
             select_related=self._select_related,
+            limit_count=rows_to_return
         )
-        new_query_set.limit_count = rows_to_return
         return new_query_set
 
     async def count(self) -> int:

--- a/orm/models.py
+++ b/orm/models.py
@@ -176,12 +176,12 @@ class QuerySet:
         expr = sqlalchemy.exists(expr).select()
         return await self.database.fetch_val(expr)
 
-    def limit(self, rows_to_return: int):
+    def limit(self, limit_count: int):
         return self.__class__(
             model_cls=self.model_cls,
             filter_clauses=self.filter_clauses,
             select_related=self._select_related,
-            limit_count=rows_to_return
+            limit_count=limit_count
         )
 
     async def count(self) -> int:

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -166,3 +166,13 @@ async def test_model_limit():
         await User.objects.create(name="Lucy")
 
         assert len(await User.objects.limit(2).all()) == 2
+
+
+@async_adapter
+async def test_model_limit_with_filter():
+    async with database:
+        await User.objects.create(name="Tom")
+        await User.objects.create(name="Tom")
+        await User.objects.create(name="Tom")
+
+        assert len(await User.objects.limit(2).filter(name__iexact='Tom').all()) == 2

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -156,3 +156,13 @@ async def test_model_count():
 
         assert await User.objects.count() == 3
         assert await User.objects.filter(name__icontains="T").count() == 1
+
+
+@async_adapter
+async def test_model_limit():
+    async with database:
+        await User.objects.create(name="Tom")
+        await User.objects.create(name="Jane")
+        await User.objects.create(name="Lucy")
+
+        assert len(await User.objects.limit(2).all()) == 2


### PR DESCRIPTION
Implements a .limit method on QuerySet that returns a QuerySet with the limit set on it

Example:
```python
await Blog.objects.limit(2).all() 
```

Implements part of:
https://github.com/encode/orm/issues/8