### PR TITLE
Add Queryset-level delete

### DIFF
--- a/orm/models.py
+++ b/orm/models.py
@@ -94,6 +94,33 @@ class QuerySet:
 
         return expr
 
+    def build_delete_expression(self):
+        assert self.filter_clauses, "Can't call delete before filter"
+        assert not self.limit_count, "Can't use delete with limit and offset"
+        primary_column = getattr(self.table.c, self.model_cls.__pkname__)
+        select_from = self.table
+
+        for item in self._select_related:
+            model_cls = self.model_cls
+            select_from = self.table
+            for part in item.split("__"):
+                model_cls = model_cls.fields[part].to
+                select_from = sqlalchemy.sql.join(select_from, model_cls.__table__)
+
+        expr = sqlalchemy.sql.select([primary_column])
+        expr = expr.select_from(select_from)
+
+        if self.filter_clauses:
+            if len(self.filter_clauses) == 1:
+                clause = self.filter_clauses[0]
+            else:
+                clause = sqlalchemy.sql.and_(*self.filter_clauses)
+            expr = expr.where(clause)
+
+        where_clause = primary_column.in_(expr)
+        expr = sqlalchemy.sql.delete(self.table).where(where_clause)
+        return expr
+
     def filter(self, **kwargs):
         filter_clauses = self.filter_clauses
         select_related = list(self._select_related)
@@ -230,6 +257,13 @@ class QuerySet:
         instance = self.model_cls(kwargs)
         instance.pk = await self.database.execute(expr)
         return instance
+
+    async def delete(self, **kwargs):
+        if kwargs:
+            return await self.filter(**kwargs).delete()
+
+        expr = self.build_delete_expression()
+        return await self.database.execute(expr)
 
 
 class Model(typesystem.Schema, metaclass=ModelMetaclass):

--- a/tests/test_foreignkey.py
+++ b/tests/test_foreignkey.py
@@ -172,3 +172,15 @@ async def test_multiple_fk():
         assert len(members) == 4
         for member in members:
             assert member.team.org.ident == "ACME Ltd"
+
+
+@async_adapter
+async def test_delete_with_fk_filter():
+    fantasies = await Album.objects.create(name="Fantasies")
+    await Track.objects.create(album=fantasies, title="Help I'm Alive", position=1)
+    await Track.objects.create(album=fantasies, title="Sick Muse", position=2)
+    await Track.objects.create(album=fantasies, title="Satellite Mind", position=3)
+
+    assert await Track.objects.filter(album=fantasies).count() == 3
+    await Track.objects.filter(album__name="Fantasies").delete()
+    assert await Track.objects.filter(album=fantasies).count() == 0

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -190,3 +190,40 @@ async def test_model_limit_with_filter():
         await User.objects.create(name="Tom")
 
         assert len(await User.objects.limit(2).filter(name__iexact='Tom').all()) == 2
+
+@async_adapter
+async def test_model_delete():
+    async with database:
+        await User.objects.create(name="Tom")
+        await User.objects.create(name="Tom")
+        await User.objects.create(name="Tom")
+
+        # It must be filtered before deletion
+        with pytest.raises(AssertionError):
+            await User.objects.delete()
+        assert len(await User.objects.all()) == 3
+
+        # Can't use delete with offset and limit
+        with pytest.raises(AssertionError):
+            await User.objects.limit(2).delete()
+        assert len(await User.objects.all()) == 3
+
+
+@async_adapter
+async def test_model_delete_with_filter():
+    async with database:
+        await User.objects.create(name="Tom")
+        await User.objects.create(name="Tom")
+        await User.objects.create(name="Jany")
+        await User.objects.create(name="Lucy")
+
+        await User.objects.filter(name="Tom").delete()
+        assert await User.objects.count() == 2
+        await User.objects.delete(name="Jany")
+        assert await User.objects.count() == 1
+
+        await Product.objects.create(name="T-Shirt", rating=5)
+        await Product.objects.create(name="Dress", rating=3)
+        await Product.objects.create(name="Coat", rating=3)
+        await Product.objects.filter(name="Dress", rating=3).delete()
+        assert await Product.objects.count() == 2


### PR DESCRIPTION
Fixes #10 
implement Queryset-level delete
I want to reuse build_select_expression, but it seems to no way to change the expression's select column.
The return value of delete method is worth discussing.
Please review