### PR TITLE
Add pk argument convert for queryset

### DIFF
--- a/orm/models.py
+++ b/orm/models.py
@@ -98,6 +98,10 @@ class QuerySet:
         filter_clauses = self.filter_clauses
         select_related = list(self._select_related)
 
+        if kwargs.get("pk"):
+            pk_name = self.model_cls.__pkname__
+            kwargs[pk_name] = kwargs.pop("pk")
+
         for key, value in kwargs.items():
             if "__" in key:
                 parts = key.split("__")

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -110,6 +110,10 @@ async def test_model_get():
         with pytest.raises(orm.MultipleMatches):
             await User.objects.get()
 
+        same_user = await User.objects.get(pk=user.id)
+        assert same_user.id == user.id
+        assert same_user.pk == user.pk
+
 
 @async_adapter
 async def test_model_filter():


### PR DESCRIPTION
Fix #34 
Model class converts the pk argument to the primary column's name, but queryset-level query didn't.
Add pk argument convert for queryset .
Now we can use User.objects.get(pk=3) .