### PR TITLE
Fix not null constraint for primary keys when inserting using postgresql

### DIFF
--- a/orm/models.py
+++ b/orm/models.py
@@ -222,6 +222,13 @@ class QuerySet:
         )
         kwargs = validator.validate(kwargs)
 
+        # Remove fields that are allowed to be NULL or auto incremented
+        kwargs = {
+            key: value
+            for key, value in kwargs.items()
+            if not (fields[key].allow_null and value is None)
+        }
+
         # Build the insert expression.
         expr = self.table.insert()
         expr = expr.values(**kwargs)

--- a/orm/models.py
+++ b/orm/models.py
@@ -222,12 +222,11 @@ class QuerySet:
         )
         kwargs = validator.validate(kwargs)
 
-        # Remove fields that are allowed to be NULL or auto incremented
-        kwargs = {
-            key: value
-            for key, value in kwargs.items()
-            if not (fields[key].allow_null and value is None)
-        }
+        # Remove primary key when None to prevent not null constraint in postgresql.
+        pkname = self.model_cls.__pkname__
+        pk = self.model_cls.fields[pkname]
+        if kwargs[pkname] is None and pk.allow_null:
+            del kwargs[pkname]
 
         # Build the insert expression.
         expr = self.table.insert()


### PR DESCRIPTION
Fixes https://github.com/encode/orm/issues/21 by removing fields that are `None` and allowed to be null from the insert statement. 