### PR TITLE
Add choices parameter to all fields

### DIFF
--- a/orm/fields.py
+++ b/orm/fields.py
@@ -42,8 +42,19 @@ class ModelField:
     def expand_relationship(self, value):
         return value
 
+class ChoiceField:
+    def __init__(self, choices=None, **kwargs):
+        super().__init__(**kwargs)
+        self._choice_class = typesystem.Choice(choices=choices)
 
-class String(ModelField, typesystem.String):
+    def validate(self, *args, **kwargs) -> typing.Any:
+        value = self._choice_class.validate(*args, **kwargs)
+        try:
+            return super().validate(*args, **kwargs)
+        except NotImplementedError:
+            return value
+
+class String(ModelField, ChoiceField, typesystem.String):
     def __init__(self, **kwargs):
         assert "max_length" in kwargs, "max_length is required"
         super().__init__(**kwargs)
@@ -57,7 +68,7 @@ class Text(ModelField, typesystem.Text):
         return sqlalchemy.Text()
 
 
-class Integer(ModelField, typesystem.Integer):
+class Integer(ModelField, ChoiceField, typesystem.Integer):
     def get_column_type(self):
         return sqlalchemy.Integer()
 

--- a/orm/fields.py
+++ b/orm/fields.py
@@ -52,7 +52,7 @@ class ModelField:
             return value
 
 
-class String(ModelField, ChoiceField, typesystem.String):
+class String(ModelField, typesystem.String):
     def __init__(self, **kwargs):
         assert "max_length" in kwargs, "max_length is required"
         super().__init__(**kwargs)
@@ -66,7 +66,7 @@ class Text(ModelField, typesystem.Text):
         return sqlalchemy.Text()
 
 
-class Integer(ModelField, ChoiceField, typesystem.Integer):
+class Integer(ModelField, typesystem.Integer):
     def get_column_type(self):
         return sqlalchemy.Integer()
 

--- a/orm/fields.py
+++ b/orm/fields.py
@@ -10,6 +10,7 @@ class ModelField:
         primary_key: bool = False,
         index: bool = False,
         unique: bool = False,
+        choices: typing.Sequence[typing.Union[str, typing.Tuple[str, str]]] = None,
         **kwargs: typing.Any,
     ) -> None:
         if primary_key:
@@ -18,6 +19,7 @@ class ModelField:
         self.primary_key = primary_key
         self.index = index
         self.unique = unique
+        self._choice_class = typesystem.Choice(choices=choices)
 
     def get_column(self, name: str) -> sqlalchemy.Column:
         column_type = self.get_column_type()
@@ -42,17 +44,13 @@ class ModelField:
     def expand_relationship(self, value):
         return value
 
-class ChoiceField:
-    def __init__(self, choices=None, **kwargs):
-        super().__init__(**kwargs)
-        self._choice_class = typesystem.Choice(choices=choices)
-
     def validate(self, *args, **kwargs) -> typing.Any:
         value = self._choice_class.validate(*args, **kwargs)
         try:
             return super().validate(*args, **kwargs)
         except NotImplementedError:
             return value
+
 
 class String(ModelField, ChoiceField, typesystem.String):
     def __init__(self, **kwargs):

--- a/orm/fields.py
+++ b/orm/fields.py
@@ -19,7 +19,9 @@ class ModelField:
         self.primary_key = primary_key
         self.index = index
         self.unique = unique
-        self._choice_class = typesystem.Choice(choices=choices)
+
+        if choices is not None:
+            self._choice_class = typesystem.Choice(choices=choices)
 
     def get_column(self, name: str) -> sqlalchemy.Column:
         column_type = self.get_column_type()
@@ -45,11 +47,12 @@ class ModelField:
         return value
 
     def validate(self, *args, **kwargs) -> typing.Any:
-        value = self._choice_class.validate(*args, **kwargs)
         try:
-            return super().validate(*args, **kwargs)
-        except NotImplementedError:
-            return value
+            self._choice_class.validate(*args, **kwargs)
+        except AttributeError:
+            pass
+
+        return super().validate(*args, **kwargs)
 
 
 class String(ModelField, typesystem.String):

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -208,7 +208,7 @@ async def test_model_choices():
             name="Dark Side of the Moon", rating=5, type="digital"
         ))
         with pytest.raises(typesystem.base.ValidationError, message="Expecting `typesystem.base.ValidationError` when creating an item with type not in choices..."):
-            await Product.objects.create(name="Tom", type="invalid"))
+            await Product.objects.create(name="Tom", type="invalid")
         with pytest.raises(typesystem.base.ValidationError, message="Expecting `typesystem.base.ValidationError` when creating an item with type that's too long..."):
             await Product.objects.create(name="Tom", type="thisistoolong")
 

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -227,16 +227,16 @@ async def test_model_choices():
 
         assert (
             len(
-                await User.objects.filter(
-                    name__iexact="Dark Side of the Moon", type="digital"
+                await Product.objects.filter(
+                    name="Dark Side of the Moon", type="digital"
                 ).all()
             )
             == 1
         )
         assert (
             len(
-                await User.objects.filter(
-                    name__iexact="Pink Floyd T-Shirt", type="physical"
+                await Product.objects.filter(
+                    name="Pink Floyd T-Shirt", type="physical"
                 ).all()
             )
             == 1

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -210,20 +210,14 @@ async def test_model_choices():
             name="Dark Side of the Moon", rating=5, type="digital"
         )
         try:
-            await Product.objects.create(name="Tom", type="invalid")
+            assert not await Product.objects.create(name="Tom", type="invalid")
         except typesystem.base.ValidationError:
             pass
-        else:
-            raise AssertionError("invalid choice 'invalid' was allowed as a type")
 
         try:
-            await Product.objects.create(name="Tom", type="thisistoolong")
+            assert not await Product.objects.create(name="Tom", type="thisistoolong")
         except typesystem.base.ValidationError:
             pass
-        else:
-            raise AssertionError(
-                " string 'thisistoolong' is longer than max length but was allowed as a type"
-            )
 
         assert (
             len(

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -210,12 +210,16 @@ async def test_model_choices():
             name="Dark Side of the Moon", rating=5, type="digital"
         )
         try:
-            assert not await Product.objects.create(name="Tom", type="invalid")
+            assert not (
+                True or await Product.objects.create(name="Tom", type="invalid")
+            )
         except typesystem.base.ValidationError:
             pass
 
         try:
-            assert not await Product.objects.create(name="Tom", type="thisistoolong")
+            assert not (
+                True or await Product.objects.create(name="Tom", type="thisistoolong")
+            )
         except typesystem.base.ValidationError:
             pass
 

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -209,7 +209,8 @@ async def test_model_limit_with_filter():
         await User.objects.create(name="Tom")
         await User.objects.create(name="Tom")
         await User.objects.create(name="Tom")
-        assert len(await User.objects.limit(2).filter(name__iexact='Tom').all()) == 2
+        assert len(await User.objects.limit(2).filter(name__iexact="Tom").all()) == 2
+
 
 @async_adapter
 async def test_model_first():
@@ -222,7 +223,7 @@ async def test_model_first():
         assert await User.objects.filter(name="Jane").first() == jane
         assert await User.objects.filter(name="Lucy").first() is None
 
-        
+
 @async_adapter
 async def test_model_choices():
     """Test that choices work properly for various types of fields."""
@@ -236,30 +237,91 @@ async def test_model_choices():
 
         with pytest.raises(typesystem.base.ValidationError):
             name, taxed, country_code = "Saudi Arabia", True, 1
-            assert all((name not in country_name_choices, taxed in country_taxed_choices, country_code in country_country_code_choices))
-            await Country.objects.create(name=name, taxed=taxed, country_code=country_code)
+            assert all(
+                (
+                    name not in country_name_choices,
+                    taxed in country_taxed_choices,
+                    country_code in country_country_code_choices,
+                )
+            )
+            await Country.objects.create(
+                name=name, taxed=taxed, country_code=country_code
+            )
 
         with pytest.raises(typesystem.base.ValidationError):
             name, taxed, country_code = "Algeria", False, 1
-            assert all((name in country_name_choices, taxed not in country_taxed_choices, country_code in country_country_code_choices))
-            await Country.objects.create(name=name, taxed=taxed, country_code=country_code)
+            assert all(
+                (
+                    name in country_name_choices,
+                    taxed not in country_taxed_choices,
+                    country_code in country_country_code_choices,
+                )
+            )
+            await Country.objects.create(
+                name=name, taxed=taxed, country_code=country_code
+            )
 
         with pytest.raises(typesystem.base.ValidationError):
             name, taxed, country_code = "Algeria", True, 967
-            assert all((name in country_name_choices, taxed in country_taxed_choices, country_code not in country_country_code_choices))
-            await Country.objects.create(name=name, taxed=taxed, country_code=country_code)
-            
-        with pytest.raises(typesystem.base.ValidationError):
-            name, taxed, country_code = "United States", True, 1 # name is too long but is a valid choice
-            assert all((name in country_name_choices, taxed in country_taxed_choices, country_code in country_country_code_choices))
-            await Country.objects.create(name=name, taxed=taxed, country_code=country_code)
+            assert all(
+                (
+                    name in country_name_choices,
+                    taxed in country_taxed_choices,
+                    country_code not in country_country_code_choices,
+                )
+            )
+            await Country.objects.create(
+                name=name, taxed=taxed, country_code=country_code
+            )
 
         with pytest.raises(typesystem.base.ValidationError):
-            name, taxed, country_code = "Algeria", True, -10 # country code is too small but is a valid choice
-            assert all((name in country_name_choices, taxed in country_taxed_choices, country_code in country_country_code_choices))
-            await Country.objects.create(name=name, taxed=taxed, country_code=country_code)
+            name, taxed, country_code = (
+                "United States",
+                True,
+                1,
+            )  # name is too long but is a valid choice
+            assert all(
+                (
+                    name in country_name_choices,
+                    taxed in country_taxed_choices,
+                    country_code in country_country_code_choices,
+                )
+            )
+            await Country.objects.create(
+                name=name, taxed=taxed, country_code=country_code
+            )
 
         with pytest.raises(typesystem.base.ValidationError):
-            name, taxed, country_code = "Algeria", True, 1200 # country code is too large but is a valid choice
-            assert all((name in country_name_choices, taxed in country_taxed_choices, country_code in country_country_code_choices))
-            await Country.objects.create(name=name, taxed=taxed, country_code=country_code)
+            name, taxed, country_code = (
+                "Algeria",
+                True,
+                -10,
+            )  # country code is too small but is a valid choice
+            assert all(
+                (
+                    name in country_name_choices,
+                    taxed in country_taxed_choices,
+                    country_code in country_country_code_choices,
+                )
+            )
+            await Country.objects.create(
+                name=name, taxed=taxed, country_code=country_code
+            )
+
+        with pytest.raises(typesystem.base.ValidationError):
+            name, taxed, country_code = (
+                "Algeria",
+                True,
+                1200,
+            )  # country code is too large but is a valid choice
+            assert all(
+                (
+                    name in country_name_choices,
+                    taxed in country_taxed_choices,
+                    country_code in country_country_code_choices,
+                )
+            )
+            await Country.objects.create(
+                name=name, taxed=taxed, country_code=country_code
+            )
+


### PR DESCRIPTION
This PR resolves #35. It uses the `typesystem.Choice` class to add choice validation to the base `ModelField` class. I have verified that it is working with at least the `Integer` and `String` fields.