### PR TITLE
Add support for `ON DELETE CASCADE`

### DIFF
--- a/orm/fields.py
+++ b/orm/fields.py
@@ -93,16 +93,17 @@ class JSON(ModelField, typesystem.Any):
 
 
 class ForeignKey(ModelField, typesystem.Field):
-    def __init__(self, to, allow_null: bool = False):
+    def __init__(self, to, allow_null: bool = False, ondelete: str = None):
         super().__init__(allow_null=allow_null)
         self.to = to
+        self.ondelete = ondelete
 
     def validate(self, value, strict=False):
         return value.pk
 
     def get_constraints(self):
         fk_string = self.to.__tablename__ + "." + self.to.__pkname__
-        return [sqlalchemy.schema.ForeignKey(fk_string)]
+        return [sqlalchemy.schema.ForeignKey(fk_string, ondelete=self.ondelete)]
 
     def get_column_type(self):
         to_column = self.to.fields[self.to.__pkname__]

--- a/orm/fields.py
+++ b/orm/fields.py
@@ -93,17 +93,17 @@ class JSON(ModelField, typesystem.Any):
 
 
 class ForeignKey(ModelField, typesystem.Field):
-    def __init__(self, to, allow_null: bool = False, ondelete: str = None):
+    def __init__(self, to, allow_null: bool = False, on_delete: str = None):
         super().__init__(allow_null=allow_null)
         self.to = to
-        self.ondelete = ondelete
+        self.on_delete = on_delete
 
     def validate(self, value, strict=False):
         return value.pk
 
     def get_constraints(self):
         fk_string = self.to.__tablename__ + "." + self.to.__pkname__
-        return [sqlalchemy.schema.ForeignKey(fk_string, ondelete=self.ondelete)]
+        return [sqlalchemy.schema.ForeignKey(fk_string, ondelete=self.on_delete)]
 
     def get_column_type(self):
         to_column = self.to.fields[self.to.__pkname__]

--- a/tests/test_foreignkey.py
+++ b/tests/test_foreignkey.py
@@ -28,7 +28,7 @@ class Track(orm.Model):
     __database__ = database
 
     id = orm.Integer(primary_key=True)
-    album = orm.ForeignKey(Album)
+    album = orm.ForeignKey(Album, ondelete="CASCADE")
     title = orm.String(max_length=100)
     position = orm.Integer()
 
@@ -172,3 +172,12 @@ async def test_multiple_fk():
         assert len(members) == 4
         for member in members:
             assert member.team.org.ident == "ACME Ltd"
+
+@async_adapter
+async def test_ondelete():
+    async with database:
+        album = await Album.objects.create(name="Malibu")
+        await Track.objects.create(album=album, title="The Bird", position=1)
+        await album.delete()
+        albums = await Album.objects.all()
+        assert len(albums) == 0

--- a/tests/test_foreignkey.py
+++ b/tests/test_foreignkey.py
@@ -28,7 +28,7 @@ class Track(orm.Model):
     __database__ = database
 
     id = orm.Integer(primary_key=True)
-    album = orm.ForeignKey(Album, ondelete="CASCADE")
+    album = orm.ForeignKey(Album, on_delete="CASCADE")
     title = orm.String(max_length=100)
     position = orm.Integer()
 
@@ -174,7 +174,7 @@ async def test_multiple_fk():
             assert member.team.org.ident == "ACME Ltd"
 
 @async_adapter
-async def test_ondelete():
+async def test_on_delete():
     async with database:
         album = await Album.objects.create(name="Malibu")
         await Track.objects.create(album=album, title="The Bird", position=1)


### PR DESCRIPTION
This PR just passes `ondelete` onto SQLAlchemy's foreign key constraint.

If set, emit `ON DELETE <value>` when issuing DDL for this constraint. Typical values include `CASCADE`, `DELETE` and `RESTRICT`.

Admittedly, this is not a very good test. However, I wasn't able to trigger a foreign key violation while running the tests against SQLite. When running the test suite against PostgreSQL, this test does fail without `ondelete="CASCADE"`.