### PR TITLE
Fix `count` on PostgreSQL

### DIFF
--- a/orm/models.py
+++ b/orm/models.py
@@ -189,7 +189,7 @@ class QuerySet:
         )
 
     async def count(self) -> int:
-        expr = self.build_select_expression()
+        expr = self.build_select_expression().alias("subquery_for_count")
         expr = sqlalchemy.func.count().select().select_from(expr)
         return await self.database.fetch_val(expr)
 

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -1,1 +1,3 @@
-DATABASE_URL = "sqlite:///test.db"
+import os
+
+DATABASE_URL = os.getenv("DATABASE_URL", "sqlite:///test.db")


### PR DESCRIPTION
In PostgreSQL, a subquery requires an alias. Prior to this change, running the test suite against PostgreSQL would result in the following failure:

> asyncpg.exceptions.PostgresSyntaxError: subquery in FROM must have an alias
> HINT:  For example, FROM (SELECT ...) [AS] foo.
