### PR TITLE
Implement `.get_or_create`

### DIFF
--- a/orm/models.py
+++ b/orm/models.py
@@ -241,6 +241,12 @@ class QuerySet:
         instance.pk = await self.database.execute(expr)
         return instance
 
+    async def get_or_create(self, **kwargs):
+        try:
+            return await self.get(**kwargs)
+        except NoMatch:
+            return await self.create(**kwargs)
+
 
 class Model(typesystem.Schema, metaclass=ModelMetaclass):
     __abstract__ = True

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -194,3 +194,16 @@ async def test_model_limit_with_filter():
         await User.objects.create(name="Tom")
 
         assert len(await User.objects.limit(2).filter(name__iexact='Tom').all()) == 2
+
+@async_adapter
+async def test_get_or_create():
+    async with database:
+        tom = await User.objects.get_or_create(name="Tom")
+        assert await User.objects.count() == 1
+
+        assert await User.objects.get_or_create(name="Tom") == tom
+        assert await User.objects.count() == 1
+
+        assert await User.objects.create(name="Tom")
+        with pytest.raises(orm.exceptions.MultipleMatches):
+            await User.objects.get_or_create(name="Tom")


### PR DESCRIPTION
This will locate a record matching conditions or create a new record if it does not exist. If multiple matching records are found, `orm.exceptions.MultipleMatches` will be raised.

