### PR TITLE
Add pagination to model query

### DIFF
--- a/orm/models.py
+++ b/orm/models.py
@@ -403,7 +403,7 @@ class _Pagination:
         return await self.query.paginate(self.page - 1, self.per_page)
 
     async def iterate(self):
-        yield await self.prev()
+        yield self
         while self.has_next:
             yield await self.next()
             self.page += 1

--- a/orm/models.py
+++ b/orm/models.py
@@ -1,4 +1,5 @@
 import typing
+import math
 
 import sqlalchemy
 import typesystem
@@ -396,14 +397,10 @@ class _Pagination:
         return self.page + 1
 
     async def next(self):
-        if self.has_next:
-            return await self.query.paginate(self.page + 1, self.per_page)
-        return await self.query.paginate(self.page, self.per_page)
+        return await self.query.paginate(self.page + 1, self.per_page)
 
     async def prev(self):
-        if self.has_prev:
-            return await self.query.paginate(self.page - 1, self.per_page)
-        return await self.query.paginate(self.page, self.per_page)
+        return await self.query.paginate(self.page - 1, self.per_page)
 
     async def iterate(self):
         yield await self.prev()

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -216,3 +216,24 @@ async def test_model_first():
         assert await User.objects.first(name="Jane") == jane
         assert await User.objects.filter(name="Jane").first() == jane
         assert await User.objects.filter(name="Lucy").first() is None
+
+@async_adapter
+async def test_pagination():
+    from random import choice  # noqa
+
+    users = (choice(["Jane", "Tom", "Carla", "Pau", "Pedro"]) for _ in range(30))
+    for user in users:
+        await User.objects.create(name=user)
+
+    per_page = 10
+    page = await User.objects.paginate(1, per_page)
+    assert page.next_num == 2
+    assert page.has_next == True
+    assert page.has_prev == False
+    assert page.pages == 3
+    first_item_id = 1
+    async for page in page.iterate():
+        assert page.items[0]["id"] == first_item_id
+        first_item_id += per_page
+    assert page.has_next == False
+    assert page.next_num == None

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -235,5 +235,8 @@ async def test_pagination():
     async for page in page.iterate():
         assert page.items[0]["id"] == first_item_id
         first_item_id += per_page
+    # Ensures that we loop across all pages
     assert page.has_next == False
     assert page.next_num == None
+    after_last_page = await page.next()
+    assert len(after_last_page.items) == 0


### PR DESCRIPTION
This adds the pagination capabilities to the model query. There is already an issue #52  questioning about how to do pagination with orm.
This implementation is influenced by the Flask-SQLAlchemy pagination method. I just removed all the stuff related with http and adapted it to fit with orm.

It's a draft because it doesn't provided any documentation example (maybe some comments and docstrings?) and I still have some doubts. See comments please.
There is also provided some tests on `tests/test_models.py::test_pagination` where we can see some use cases