### PR TITLE
add bulk_create to QuerySet for batched inserts

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,6 @@ class Note(orm.Model):
     __tablename__ = "notes"
     __database__ = database
     __metadata__ = metadata
-
     id = orm.Integer(primary_key=True)
     text = orm.String(max_length=100)
     completed = orm.Boolean(default=False)
@@ -52,6 +51,13 @@ metadata.create_all(engine)
 await Note.objects.create(text="Buy the groceries.", completed=False)
 await Note.objects.create(text="Call Mum.", completed=True)
 await Note.objects.create(text="Send invoices.", completed=True)
+
+# .bulk_create()
+await Note.objects.bulk_create([
+    Note(text="Buy the groceries.", completed=False),
+    Note(text="Call Mum.", completed=True),
+    Note(text="Send invoices.", completed=True),
+])
 
 # .all()
 notes = await Note.objects.all()

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -216,3 +216,15 @@ async def test_model_first():
         assert await User.objects.first(name="Jane") == jane
         assert await User.objects.filter(name="Jane").first() == jane
         assert await User.objects.filter(name="Lucy").first() is None
+
+
+@async_adapter
+async def test_model_bulk_create():
+    async with database:
+        await User.objects.bulk_create([
+            User(name="Tom"),
+            User(name="Jane"),
+            User(name="Lucy"),
+        ])
+
+        assert await User.objects.count() == 3


### PR DESCRIPTION
When you have an array of objects to put in the db, insert all of them at once in a single query:

```python
entries = [
    Entry(headline='This is a test'),
    Entry(headline='This is only a test'),
]

# no return value; primary keys on object instances are not populated
Entry.objects.bulk_create(entries)
```

Inspired by Django's [bulk_create](https://docs.djangoproject.com/en/3.0/ref/models/querysets/#bulk-create). The `batch_size` and `ignore_conflicts` arguments are not implemented.