### PR TITLE
Implement multi-column constraints.

### DIFF
--- a/orm/models.py
+++ b/orm/models.py
@@ -34,6 +34,7 @@ class ModelMetaclass(SchemaMetaclass):
 
         tablename = attrs["__tablename__"]
         metadata = attrs["__metadata__"]
+        table_args = attrs.get("__table_args__", [])
         pkname = None
 
         columns = []
@@ -41,6 +42,7 @@ class ModelMetaclass(SchemaMetaclass):
             if field.primary_key:
                 pkname = name
             columns.append(field.get_column(name))
+        columns.extend(table_args)
 
         new_model.__table__ = sqlalchemy.Table(tablename, metadata, *columns)
         new_model.__pkname__ = pkname


### PR DESCRIPTION
Created for https://github.com/encode/orm/issues/72.

This allows for the pass-through of table arguments to the underlying sqlalchemy table. In particular, the passing of `UniqueConstraint`.

This PR should not be considered complete, but requesting input. Two subjects of particular concern are:

- the above implementation will require importing `UniqueConstraint` from `sqlalchemy.schema` when used. Is this fine? Theoretically this multi-column uniqueness shouldn't be as prevalent as single column uniqueness (which only requires passing `unique=True`). Thus, perhaps it makes sense to necessitate directly reference to sqlalchemy in these rare cases.
- As can be seen in my test, I perform `from sqlite3 import IntegrityError`. This is what I used because the exception raised by `aiosqlite` is not encapsulated by `from sqlalchemy.exc import IntegrityError`. Thus, I question how to deal with the issue that `aiosqlite`'s `IntegrityError` isn't being caught using a cross-DB solution.

More on the second point, I don't know if that means I should open up an issue with `aiosqlite`.