### PR TITLE
Add Model and Queryset .all() as_dict support

### DIFF
--- a/orm/__init__.py
+++ b/orm/__init__.py
@@ -1,5 +1,16 @@
 from orm.exceptions import MultipleMatches, NoMatch
-from orm.fields import Boolean, Integer, Float, String, Text, Date, Time, DateTime, JSON, ForeignKey
+from orm.fields import (
+    JSON,
+    Boolean,
+    Date,
+    DateTime,
+    Float,
+    ForeignKey,
+    Integer,
+    String,
+    Text,
+    Time,
+)
 from orm.models import Model
 
 __version__ = "0.1.4"

--- a/tests/test_columns.py
+++ b/tests/test_columns.py
@@ -2,14 +2,12 @@ import asyncio
 import datetime
 import functools
 
+import databases
 import pytest
 import sqlalchemy
 
-import databases
 import orm
-
 from tests.settings import DATABASE_URL
-
 
 database = databases.Database(DATABASE_URL, force_rollback=True)
 metadata = sqlalchemy.MetaData()
@@ -63,7 +61,7 @@ async def test_model_crud():
         example = await Example.objects.get()
         assert example.created.year == datetime.datetime.now().year
         assert example.created_day == datetime.date.today()
-        assert example.description == ''
+        assert example.description == ""
         assert example.value is None
         assert example.data == {}
 

--- a/tests/test_foreignkey.py
+++ b/tests/test_foreignkey.py
@@ -1,12 +1,11 @@
 import asyncio
 import functools
 
+import databases
 import pytest
 import sqlalchemy
 
-import databases
 import orm
-
 from tests.settings import DATABASE_URL
 
 database = databases.Database(DATABASE_URL, force_rollback=True)
@@ -89,7 +88,9 @@ async def test_model_crud():
     async with database:
         album = await Album.objects.create(name="Malibu")
         await Track.objects.create(album=album, title="The Bird", position=1)
-        await Track.objects.create(album=album, title="Heart don't stand a chance", position=2)
+        await Track.objects.create(
+            album=album, title="Heart don't stand a chance", position=2
+        )
         await Track.objects.create(album=album, title="The Waters", position=3)
 
         track = await Track.objects.get(title="The Bird")
@@ -104,7 +105,9 @@ async def test_select_related():
     async with database:
         album = await Album.objects.create(name="Malibu")
         await Track.objects.create(album=album, title="The Bird", position=1)
-        await Track.objects.create(album=album, title="Heart don't stand a chance", position=2)
+        await Track.objects.create(
+            album=album, title="Heart don't stand a chance", position=2
+        )
         await Track.objects.create(album=album, title="The Waters", position=3)
 
         fantasies = await Album.objects.create(name="Fantasies")
@@ -124,7 +127,9 @@ async def test_fk_filter():
     async with database:
         malibu = await Album.objects.create(name="Malibu")
         await Track.objects.create(album=malibu, title="The Bird", position=1)
-        await Track.objects.create(album=malibu, title="Heart don't stand a chance", position=2)
+        await Track.objects.create(
+            album=malibu, title="Heart don't stand a chance", position=2
+        )
         await Track.objects.create(album=malibu, title="The Waters", position=3)
 
         fantasies = await Album.objects.create(name="Fantasies")
@@ -132,12 +137,20 @@ async def test_fk_filter():
         await Track.objects.create(album=fantasies, title="Sick Muse", position=2)
         await Track.objects.create(album=fantasies, title="Satellite Mind", position=3)
 
-        tracks = await Track.objects.select_related("album").filter(album__name="Fantasies").all()
+        tracks = (
+            await Track.objects.select_related("album")
+            .filter(album__name="Fantasies")
+            .all()
+        )
         assert len(tracks) == 3
         for track in tracks:
             assert track.album.name == "Fantasies"
 
-        tracks = await Track.objects.select_related("album").filter(album__name__icontains="fan").all()
+        tracks = (
+            await Track.objects.select_related("album")
+            .filter(album__name__icontains="fan")
+            .all()
+        )
         assert len(tracks) == 3
         for track in tracks:
             assert track.album.name == "Fantasies"
@@ -168,7 +181,11 @@ async def test_multiple_fk():
         team = await Team.objects.create(org=other, name="Green Team")
         await Member.objects.create(team=team, email="e@example.org")
 
-        members = await Member.objects.select_related('team__org').filter(team__org__ident="ACME Ltd").all()
+        members = (
+            await Member.objects.select_related("team__org")
+            .filter(team__org__ident="ACME Ltd")
+            .all()
+        )
         assert len(members) == 4
         for member in members:
             assert member.team.org.ident == "ACME Ltd"

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,12 +1,11 @@
 import asyncio
 import functools
 
+import databases
 import pytest
 import sqlalchemy
 
-import databases
 import orm
-
 from tests.settings import DATABASE_URL
 
 database = databases.Database(DATABASE_URL, force_rollback=True)
@@ -193,7 +192,7 @@ async def test_model_limit_with_filter():
         await User.objects.create(name="Tom")
         await User.objects.create(name="Tom")
 
-        assert len(await User.objects.limit(2).filter(name__iexact='Tom').all()) == 2
+        assert len(await User.objects.limit(2).filter(name__iexact="Tom").all()) == 2
 
 
 @async_adapter
@@ -203,7 +202,7 @@ async def test_offset():
         await User.objects.create(name="Jane")
 
         users = await User.objects.offset(1).limit(1).all()
-        assert users[0].name == 'Jane'
+        assert users[0].name == "Jane"
 
 
 @async_adapter
@@ -216,3 +215,17 @@ async def test_model_first():
         assert await User.objects.first(name="Jane") == jane
         assert await User.objects.filter(name="Jane").first() == jane
         assert await User.objects.filter(name="Lucy").first() is None
+
+
+@async_adapter
+async def test_as_dict():
+    async with database:
+        tom = await User.objects.create(name="Tom")
+        jane = await User.objects.create(name="Jane")
+        users = await User.objects.all()
+
+        assert await tom.as_dict() == {"id": 1, "name": "Tom"}
+        assert await users.as_dict() == [
+            {"id": 1, "name": "Tom"},
+            {"id": 2, "name": "Jane"},
+        ]


### PR DESCRIPTION
As-Is:
ORM model does not support its own dictionary serialize method

To-be:
ORM model can be serialized to dict like this:
```await User.objects.get(id=1).as_dict()```
or Queryset.all() that returns ORM model objects' list can be serialized to dict like this:
```await User.objects.all().as_dict()```

+ I run lint script