### PR TITLE
Fixing iexact behaviour

### DIFF
--- a/orm/models.py
+++ b/orm/models.py
@@ -144,7 +144,7 @@ class QuerySet:
             op_attr = FILTER_OPERATORS[op]
             has_escaped_character = False
 
-            if op in ["contains", "icontains"]:
+            if op in ["iexact", "contains", "icontains"]:
                 has_escaped_character = any(c for c in self.ESCAPE_CHARACTERS
                                             if c in value)
                 if has_escaped_character:


### PR DESCRIPTION
This PR fixes the behaviour noted in #85 by ensuring escape characters are properly escaped when using `iexact`.

TLDR; `iexact` behaved as a case insensitive LIKE instead of case insensitive exact match.