### PR TITLE
Feature: Adding a `LIKE` operator

### DIFF
--- a/orm/models.py
+++ b/orm/models.py
@@ -13,6 +13,7 @@ FILTER_OPERATORS = {
     "iexact": "ilike",
     "contains": "like",
     "icontains": "ilike",
+    "like": "like",
     "in": "in_",
     "gt": "__gt__",
     "gte": "__ge__",


### PR DESCRIPTION
Addresses concern in #85.
This adds an explicit `LIKE` operator. The idea it to enable developers to implement wildcard-based searches (such as prefix/suffix match).