### PR TITLE
Queryset-level delete method

### DIFF
--- a/docs/making_queries.md
+++ b/docs/making_queries.md
@@ -1,7 +1,3 @@
-## Queryset methods
-
-ORM supports a range of query methods which can be chained together.
-
 Let's say you have the following model defined:
 
 ```python
@@ -22,54 +18,30 @@ class Note(orm.Model):
     }
 ```
 
-You can use the following queryset methods:
-
-### Creating instances
-
-You need to pass the required model attributes and values to the `.create()` method:
+ORM supports two types of queryset methods.
+Some queryset methods return another queryset and can be chianed together like `.filter()`:
 
 ```python
-await Note.objects.create(text="Buy the groceries.", completed=False)
-await Note.objects.create(text="Call Mum.", completed=True)
-await Note.objects.create(text="Send invoices.", completed=True)
+Note.objects.filter().filter()
 ```
 
-### Querying instances
-
-#### .all()
-
-To retrieve all the instances:
+Other queryset methods return results and should be used as final method on the queryset like `.all()`:
 
 ```python
-notes = await Note.objects.all()
+Note.objects.filter().all()
 ```
 
-#### .get()
+## Returning Querysets
 
-To get only one instance:
+### .exclude()
+
+To exclude instances:
 
 ```python
-note = await Note.objects.get(id=1)
+notes = await Note.objects.exclude(completed=False).all()
 ```
 
-**Note**: `.get()` expects to find only one instance. This can raise `NoMatch` or `MultipleMatches`.
-
-#### .first()
-
-This will return the first instance or `None`:
-
-```python
-note = await Note.objects.filter(completed=True).first()
-```
-
-`pk` always refers to the model's primary key field:
-
-```python
-note = await Note.objects.get(pk=2)
-note.pk  # 2
-```
-
-#### .filter()
+### .filter()
 
 To filter instances:
 
@@ -97,25 +69,7 @@ notes = await Note.objects.filter(text__icontains="mum").all()
 notes = await Note.objects.filter(id__in=[1, 2, 3]).all()
 ```
 
-#### .exclude()
-
-To exclude instances:
-
-```python
-notes = await Note.objects.exclude(completed=False).all()
-```
-
-#### .order_by()
-
-To order query results:
-
-```python
-notes = await Note.objects.order_by("text", "-id").all()
-```
-
-**Note**: This will sort by ascending `text` and descending `id`.
-
-#### .limit()
+### .limit()
 
 To limit number of results:
 
@@ -123,7 +77,7 @@ To limit number of results:
 await Note.objects.limit(1).all()
 ```
 
-#### .offset()
+### .offset()
 
 To apply offset to query results:
 
@@ -139,7 +93,60 @@ await Note.objects.order_by("id").limit(1).offset(1).all()
 await Note.objects.filter(text__icontains="mum").limit(2).all()
 ```
 
-#### .exists()
+### .order_by()
+
+To order query results:
+
+```python
+notes = await Note.objects.order_by("text", "-id").all()
+```
+
+!!! note
+    This will sort by ascending `text` and descending `id`.
+
+## Returning results
+
+### .all()
+
+To retrieve all the instances:
+
+```python
+notes = await Note.objects.all()
+```
+
+### .create()
+
+You need to pass the required model attributes and values to the `.create()` method:
+
+```python
+await Note.objects.create(text="Buy the groceries.", completed=False)
+await Note.objects.create(text="Call Mum.", completed=True)
+await Note.objects.create(text="Send invoices.", completed=True)
+```
+
+### .delete()
+
+You can `delete` instances by calling `.delete()` on a queryset:
+
+```python
+await Note.objects.filter(completed=True).delete()
+```
+
+It's not very common, but to delete all rows in a table:
+
+```python
+await Note.objects.delete()
+```
+
+You can also call delete on a queried instance:
+
+```python
+note = await Note.objects.first()
+
+await note.delete()
+```
+
+### .exists()
 
 To check if any instances matching the query exist. Returns `True` or `False`.
 
@@ -147,7 +154,33 @@ To check if any instances matching the query exist. Returns `True` or `False`.
 await Note.objects.filter(completed=True).exists()
 ```
 
-### Updating instances
+### .first()
+
+This will return the first instance or `None`:
+
+```python
+note = await Note.objects.filter(completed=True).first()
+```
+
+`pk` always refers to the model's primary key field:
+
+```python
+note = await Note.objects.get(pk=2)
+note.pk  # 2
+```
+
+### .get()
+
+To get only one instance:
+
+```python
+note = await Note.objects.get(id=1)
+```
+
+!!! note
+    `.get()` expects to find only one instance. This can raise `NoMatch` or `MultipleMatches`.
+
+### .update()
 
 `.update()` method is defined on model instances.
 You need to query to get a `Note` instance first:
@@ -162,24 +195,9 @@ Then update the field(s):
 await note.update(completed=True)
 ```
 
-### Deleting instances
+## Convenience Methods
 
-`.delete()` method is defined on model instances.
-You need to query to get a `Note` instance first:
-
-```python
-note = await Note.objects.first()
-```
-
-Then delete the instance:
-
-```python
-await note.delete()
-```
-
-### Convenience methods
-
-#### get_or_create()
+### .get_or_create()
 
 To get an existing instance matching the query, or create a new one.
 This will retuurn a tuple of `instance` and `created`.
@@ -188,4 +206,5 @@ This will retuurn a tuple of `instance` and `created`.
 note, created = await Note.objects.get_or_create(text="Going to car wash")
 ```
 
-**Note**: Since this is doing a [get()](#get), it can raise `MultipleMatches` exception.
+!!! note
+    Since `get_or_create()` is doing a [get()](#get), it can raise `MultipleMatches` exception.

--- a/tests/test_columns.py
+++ b/tests/test_columns.py
@@ -27,14 +27,14 @@ class StatusEnum(Enum):
 class Example(orm.Model):
     registry = models
     fields = {
-        "id": orm.Integer(primary_key=True),
-        "uuid": orm.UUID(allow_null=True),
+        "uuid": orm.UUID(primary_key=True, default=uuid.uuid4),
         "created": orm.DateTime(default=datetime.datetime.now),
         "created_day": orm.Date(default=datetime.date.today),
         "created_time": orm.Time(default=time),
         "data": orm.JSON(default={}),
         "description": orm.Text(allow_blank=True),
         "huge_number": orm.BigInteger(default=0),
+        "number": orm.Integer(allow_null=True),
         "price": orm.Decimal(max_digits=5, decimal_places=2, allow_null=True),
         "status": orm.Enum(StatusEnum, default=StatusEnum.DRAFT),
         "value": orm.Float(allow_null=True),
@@ -64,22 +64,23 @@ async def test_model_crud():
     assert example.data == {}
     assert example.description == ""
     assert example.huge_number == 0
+    assert example.number is None
     assert example.price is None
     assert example.status == StatusEnum.DRAFT
-    assert example.uuid is None
     assert example.value is None
+    assert isinstance(example.uuid, uuid.UUID)
 
     await example.update(
         data={"foo": 123},
         value=123.456,
+        number=10,
         status=StatusEnum.RELEASED,
         price=decimal.Decimal("999.99"),
-        uuid=uuid.UUID("01175cde-c18f-4a13-a492-21bd9e1cb01b"),
     )
 
     example = await Example.objects.get()
     assert example.value == 123.456
+    assert example.number == 10
     assert example.data == {"foo": 123}
     assert example.status == StatusEnum.RELEASED
     assert example.price == decimal.Decimal("999.99")
-    assert example.uuid == uuid.UUID("01175cde-c18f-4a13-a492-21bd9e1cb01b")

--- a/tests/test_foreignkey.py
+++ b/tests/test_foreignkey.py
@@ -166,3 +166,15 @@ async def test_multiple_fk():
     assert len(members) == 4
     for member in members:
         assert member.team.org.ident == "ACME Ltd"
+
+
+async def test_queryset_delete_with_fk():
+    malibu = await Album.objects.create(name="Malibu")
+    await Track.objects.create(album=malibu, title="The Bird", position=1)
+
+    wall = await Album.objects.create(name="The Wall")
+    await Track.objects.create(album=wall, title="The Wall", position=1)
+
+    await Track.objects.filter(album=malibu).delete()
+    assert await Track.objects.filter(album=malibu).count() == 0
+    assert await Track.objects.filter(album=wall).count() == 1

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -254,11 +254,26 @@ async def test_model_search():
 
 
 async def test_model_get_or_create():
-    async with database:
-        user, created = await User.objects.get_or_create(name="Tom")
+    user, created = await User.objects.get_or_create(name="Tom")
 
-        assert created is True
-        assert await User.objects.get(pk=user.id) == user
+    assert created is True
+    assert await User.objects.get(pk=user.id) == user
 
-        user, created = await User.objects.get_or_create(name="Tom")
-        assert created is False
+    user, created = await User.objects.get_or_create(name="Tom")
+    assert created is False
+
+
+async def test_queryset_delete():
+    shirt = await Product.objects.create(name="Shirt", rating=5)
+    belt = await Product.objects.create(name="Belt", rating=5)
+    await Product.objects.create(name="Tie", rating=5)
+    await Product.objects.create(name="Trousers", rating=5)
+
+    await Product.objects.delete(pk=shirt.id)
+    assert await Product.objects.count() == 3
+
+    await Product.objects.filter(pk=belt.id).delete()
+    assert await Product.objects.count() == 2
+
+    await Product.objects.delete()
+    assert await Product.objects.count() == 0


### PR DESCRIPTION
Closes #10.

Add Queryset-level delete method:

```python
await Note.objects.filter(completed=True).delete()
```

Or
```python
await Note.objects.delete(completed=True)
```

Ideally it would return number of modified rows, it's easy to add `.returning()` method but at the moment supported sqlite version in python doesn't support `RETURNING` clauses yet ([ref](https://www.sqlite.org/releaselog/3_35_0.html)).

Any feedback is appreciated.