### PR TITLE
queryset-level update method

### DIFF
--- a/docs/making_queries.md
+++ b/docs/making_queries.md
@@ -138,7 +138,7 @@ It's not very common, but to delete all rows in a table:
 await Note.objects.delete()
 ```
 
-You can also call delete on a queried instance:
+You can also call `.delete()` on a queried instance:
 
 ```python
 note = await Note.objects.first()
@@ -182,16 +182,23 @@ note = await Note.objects.get(id=1)
 
 ### .update()
 
-`.update()` method is defined on model instances.
-You need to query to get a `Note` instance first:
+You can update instances by calling `.update()` on a queryset:
+
+```python
+await Note.objects.filter(completed=True).update(completed=False)
+```
+
+It's not very common, but to update all rows in a table:
+
+```python
+await Note.objects.update(completed=False)
+```
+
+You can also call `.update()` on a queried instance:
 
 ```python
 note = await Note.objects.first()
-```
 
-Then update the field(s):
-
-```python
 await note.update(completed=True)
 ```
 

--- a/tests/test_foreignkey.py
+++ b/tests/test_foreignkey.py
@@ -178,3 +178,13 @@ async def test_queryset_delete_with_fk():
     await Track.objects.filter(album=malibu).delete()
     assert await Track.objects.filter(album=malibu).count() == 0
     assert await Track.objects.filter(album=wall).count() == 1
+
+
+async def test_queryset_update_with_fk():
+    malibu = await Album.objects.create(name="Malibu")
+    wall = await Album.objects.create(name="The Wall")
+    await Track.objects.create(album=malibu, title="The Bird", position=1)
+
+    await Track.objects.filter(album=malibu).update(album=wall)
+    assert await Track.objects.filter(album=malibu).count() == 0
+    assert await Track.objects.filter(album=wall).count() == 1

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -273,3 +273,17 @@ async def test_queryset_delete():
 
     await Product.objects.delete()
     assert await Product.objects.count() == 0
+
+
+async def test_queryset_update():
+    shirt = await Product.objects.create(name="Shirt", rating=5)
+    tie = await Product.objects.create(name="Tie", rating=5)
+
+    await Product.objects.filter(pk=shirt.id).update(rating=3)
+    shirt = await Product.objects.get(pk=shirt.id)
+    assert shirt.rating == 3
+    assert await Product.objects.get(pk=tie.id) == tie
+
+    await Product.objects.update(rating=3)
+    tie = await Product.objects.get(pk=tie.id)
+    assert tie.rating == 3


### PR DESCRIPTION
Closes #9 

You can update instances by calling `.update()` on a queryset:

```python
await Note.objects.filter(completed=True).update(completed=False)
```

It's not very common, but to update all rows in a table:

```python
await Note.objects.update(completed=False)
```