### PR TITLE
fix create method for non-integer pk

### DIFF
--- a/orm/models.py
+++ b/orm/models.py
@@ -392,7 +392,7 @@ class QuerySet:
             if value.validator.read_only and value.validator.has_default():
                 kwargs[key] = value.validator.get_default_value()
 
-        if self.model_cls.database.url.dialect == "sqlite":
+        if self.model_cls.database.url.dialect in ["mysql", "sqlite"]:
             expr = self.table.insert().values(**kwargs)
         else:
             pk_column = getattr(self.table.c, self.pkname)

--- a/orm/models.py
+++ b/orm/models.py
@@ -392,14 +392,14 @@ class QuerySet:
             if value.validator.read_only and value.validator.has_default():
                 kwargs[key] = value.validator.get_default_value()
 
-        if self.model_cls.database.url.dialect in ["mysql", "sqlite"]:
-            expr = self.table.insert().values(**kwargs)
-        else:
-            pk_column = getattr(self.table.c, self.pkname)
-            expr = self.table.insert().values(**kwargs).returning(pk_column)
-
         instance = self.model_cls(**kwargs)
-        instance.pk = await self.database.execute(expr)
+        expr = self.table.insert().values(**kwargs)
+
+        if self.pkname not in kwargs:
+            instance.pk = await self.database.execute(expr)
+        else:
+            await self.database.execute(expr)
+
         return instance
 
     async def delete(self) -> None:

--- a/tests/test_columns.py
+++ b/tests/test_columns.py
@@ -93,8 +93,10 @@ async def test_model_crud():
     assert product.uuid == uuid.UUID("01175cde-c18f-4a13-a492-21bd9e1cb01b")
 
 
-@pytest.mark.skipif(database.url.dialect == "sqlite", reason="Not supported on SQLite")
 async def test_model_crud_with_non_integer_pk():
+    if database.url.dialect in ["mysql", "sqlite"]:
+        pytest.skip("RETURNING clause not supported.")
+
     user = await User.objects.create(name="Chris")
 
     assert isinstance(user.pk, uuid.UUID)

--- a/tests/test_columns.py
+++ b/tests/test_columns.py
@@ -92,12 +92,6 @@ async def test_model_crud():
     assert product.price == decimal.Decimal("999.99")
     assert product.uuid == uuid.UUID("01175cde-c18f-4a13-a492-21bd9e1cb01b")
 
-
-async def test_model_crud_with_non_integer_pk():
-    if database.url.dialect in ["mysql", "sqlite"]:
-        pytest.skip("RETURNING clause not supported.")
-
     user = await User.objects.create(name="Chris")
-
     assert isinstance(user.pk, uuid.UUID)
     assert await User.objects.get(pk=user.pk) == user

--- a/tests/test_columns.py
+++ b/tests/test_columns.py
@@ -64,9 +64,9 @@ async def rollback_transactions():
 
 
 async def test_model_crud():
-    await Product.objects.create()
+    product = await Product.objects.create()
 
-    product = await Product.objects.get()
+    product = await Product.objects.get(pk=product.pk)
     assert product.created.year == datetime.datetime.now().year
     assert product.created_day == datetime.date.today()
     assert product.data == {}
@@ -92,6 +92,10 @@ async def test_model_crud():
     assert product.price == decimal.Decimal("999.99")
     assert product.uuid == uuid.UUID("01175cde-c18f-4a13-a492-21bd9e1cb01b")
 
-    await User.objects.create(name="Chris")
-    user = await User.objects.get(name="Chris")
-    assert user.name == "Chris"
+
+@pytest.mark.skipif(database.url.dialect == "sqlite", reason="Not supported on SQLite")
+async def test_model_crud_with_non_integer_pk():
+    user = await User.objects.create(name="Chris")
+
+    assert isinstance(user.pk, uuid.UUID)
+    assert await User.objects.get(pk=user.pk) == user


### PR DESCRIPTION
Fixes #47 

Queryset method `create` does not work with non-integer primary keys.
This PR will check if `PK` is not in `create` method arguments, use the one assigned from db, otherwise use the one passed in arguments.