### PR TITLE
Add metadata property

### DIFF
--- a/orm/__init__.py
+++ b/orm/__init__.py
@@ -22,7 +22,7 @@ from orm.fields import (
 )
 from orm.models import Model, ModelRegistry
 
-__version__ = "0.3.0"
+__version__ = "0.3.1"
 __all__ = [
     "CASCADE",
     "RESTRICT",


### PR DESCRIPTION
Adds a `metadata` property to call `model_cls.build_table()` whenever `metadata` is accessed.

This is useful when working with `create_table` or `alembic`.