### PR TITLE
docs: Fix a few typos

### DIFF
--- a/docs/making_queries.md
+++ b/docs/making_queries.md
@@ -19,7 +19,7 @@ class Note(orm.Model):
 ```
 
 ORM supports two types of queryset methods.
-Some queryset methods return another queryset and can be chianed together like `.filter()` and `order_by`:
+Some queryset methods return another queryset and can be chained together like `.filter()` and `order_by`:
 
 ```python
 Note.objects.filter(completed=True).order_by("id")
@@ -266,7 +266,7 @@ note, created = await Note.objects.update_or_create(
 
 This will query a `Note` with `text` as `"Going to car wash"`,
 if an instance is found, it will use the `defaults` argument to update the instance.
-If it matches no records, it will use the comibnation of arguments to create the new instance.
+If it matches no records, it will use the combination of arguments to create the new instance.
 
 !!! note
     Since `update_or_create()` is doing a [get()](#get), it can raise `MultipleMatches` exception.

--- a/docs/relationships.md
+++ b/docs/relationships.md
@@ -72,7 +72,7 @@ track = await Track.objects.select_related("album").get(title="The Bird")
 assert track.album.name == "Malibu"
 ```
 
-To fetch an instance, filtering across a foregin key relationship:
+To fetch an instance, filtering across a foreign key relationship:
 
 ```python
 tracks = Track.objects.filter(album__name="Fantasies")
@@ -84,7 +84,7 @@ assert len(tracks) == 2
 
 ### ForeignKey constraints
 
-`ForeigknKey` supports specfiying a constraint through `on_delete` argument.
+`ForeigknKey` supports specifying a constraint through `on_delete` argument.
 
 This will result in a SQL `ON DELETE` query being generated when the referenced object is removed.
 


### PR DESCRIPTION
There are small typos in:
- docs/making_queries.md
- docs/relationships.md

Fixes:
- Should read `specifying` rather than `specfiying`.
- Should read `foreign` rather than `foregin`.
- Should read `combination` rather than `comibnation`.
- Should read `chained` rather than `chianed`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md